### PR TITLE
Fix documentation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - [Templates](#templates)
 
 ## Introduction
-This repository contains a guide and templates for using iptables, here you will find an introduction to iptables, a powerful tool for configuring and managing firewall rules on Linux systems firewall rules.
+This repository contains a guide and templates for using iptables, here you will find an introduction to iptables, a powerful tool for configuring and managing firewall rules on Linux systems.
 iptables can help you protect your server from various cyber attacks, such as DDoS, brute force, SQL injection, XSS, etc.
 - The guide explains the basic syntax and concepts of iptables,
 - the templates provide ready-to-use rules for common scenarios and use cases.
@@ -22,7 +22,7 @@ The guide covers the following topics:
 - How to save, restore, and reload iptables rules?
 - How to troubleshoot and debug iptables rules?
 
-The guide is available in the `guide` directory of this repository.
+The guide is available in the `iptables-complete-guide` directory of this repository.
 
 ## Templates
 
@@ -33,4 +33,4 @@ The templates are collections of iptables rules that address specific security c
 - The templates are based on best practices and common scenarios, but they are not meant to be used as-is without proper testing and customization.
 - They are designed to help you protect your server from various cyber attacks, such as DDoS, brute force, SQL injection, XSS, etc.
 - You can use the templates as a starting point or a reference for creating your own iptables rules and modify, combine, or extend the templates to suit your needs.
-- The templates cover a wide range of cebersecurity topics.
+- The templates cover a wide range of cybersecurity topics.

--- a/iptables-templates/README.md
+++ b/iptables-templates/README.md
@@ -79,14 +79,14 @@ Ensure you have root privileges or sudo access to run iptables commands.
     sudo iptables-restore -n < templates/block-malicious-user-agents.rules.v4
     ```
 
-- To insert a template's rules at a specific position in your existing chains, use the -I option with a line number:
+- To insert a template's rules at a specific position in your existing chains, use the `iptables` command with the `-I` option:
    ```bash
-   sudo iptables-restore -I 5 < templates/block-malicious-user-agents.rules.v4
+   sudo iptables -I INPUT 5 <rule>
    ```
 
-- To remove a template, use the iptables-flush command. For example, to remove the block-malicious-user-agents.rules.v4 template, run:
+- To remove a template, flush the appropriate chain using the `iptables -F` command. For example, to clear the `INPUT` chain, run:
    ```bash
-   sudo iptables-flush INPUT
+   sudo iptables -F INPUT
    ```
 
 - To save a template, use the iptables-save command. For example, to save the block-malicious-user-agents.rules.v4 template, run:


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `iptables-templates/README.md` files to improve clarity, fix typos, and correct instructions for using iptables templates. Below are the most important changes grouped by theme:

### Documentation Improvements:

* Fixed a grammar issue in the introduction of `README.md` to make the description of iptables more concise and clear.
* Corrected a typo in `README.md`, changing "cebersecurity" to "cybersecurity."
* Updated the directory reference in `README.md` from `guide` to `iptables-complete-guide` for accuracy.

### Command Clarifications:

* Improved instructions in `iptables-templates/README.md` for inserting rules, specifying the correct use of the `iptables` command with the `-I` option.
* Updated instructions in `iptables-templates/README.md` for removing rules, replacing `iptables-flush` with the correct `iptables -F` syntax.## Summary
- correct repeated phrase and path references in README
- fix typo 'cebersecurity'
- remove invalid iptables commands and suggest valid alternatives in templates

## Testing
- `markdownlint README.md iptables-complete-guide/README.md iptables-templates/README.md`

------
https://chatgpt.com/codex/tasks/task_e_684ab30e24888330a548bd3a6e363fde